### PR TITLE
fix: Don't panic on NetworkErrors on wasm

### DIFF
--- a/examples/web_image.rs
+++ b/examples/web_image.rs
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn_bundle(SpriteBundle {
         // Simply use a url where you would normally use an asset folder relative path
-        texture: asset_server.load("https://johanhelsing.studio/assets/favicon.png"),
+        texture: asset_server.load("https://s3.johanhelsing.studio/dump/favicon.png"),
         ..default()
     });
 }


### PR DESCRIPTION
Instead warn before reporting the asset as `AssetIoError::NotFound`, same as we do on native.

Ideally, we'd handle the actual errors, but this makes the two implementation behave similarly at least.

Fixes: #4