### PR TITLE
Expose WebAssetReader as part of the public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["gamedev", "networking", "wasm", "bevy"]
 license = "MIT OR Apache-2.0"
 name = "bevy_web_asset"
 repository = "https://github.com/johanhelsing/bevy_web_asset"
-version = "0.7.0"
+version = "0.7.1"
 
 [dependencies]
 bevy = {version = "0.12", default-features = false, features = ["bevy_asset"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ mod web_asset_plugin;
 mod web_asset_source;
 
 pub use web_asset_plugin::WebAssetPlugin;
+pub use web_asset_source::WebAssetReader;

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -4,8 +4,11 @@ use std::path::{Path, PathBuf};
 
 use bevy::asset::io::{AssetReader, AssetReaderError, Reader};
 
-pub(super) enum WebAssetReader {
+/// Treats paths as urls to load assets from.
+pub enum WebAssetReader {
+    /// Unencrypted connections.
     Http,
+    /// Use TLS for setting up connections.
     Https,
 }
 


### PR DESCRIPTION
I would like to reuse the implementation of this crate, but do two things:

* write my own wrapper `AssetReader` around it (hardcoded base url and some other shenanigans)
* use it as a default `AssetReader`

Exposing the web asset reader publicly will achieve this, as I can then use the `AssetReader` impl (which is public by definition) and invoke it from my own `AssetReader` impl