### PR TITLE
 Reintroduce android support 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.7.1"
 
 [dependencies]
 bevy = {version = "0.12", default-features = false, features = ["bevy_asset"]}
+pin-project = "1.1.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 isahc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bevy = {version = "0.12", default-features = false, features = ["bevy_asset"]}
 pin-project = "1.1.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-isahc = "1"
+surf = {version = "2.3", default-features = false, features = ["h1-client-rustls"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = {version = "0.3.22", default-features = false}


### PR DESCRIPTION
fixes #22

isahc does not support android in a released version, only on the latest branch, but the maintainer does not currently have time to maintain it.

This PR reverts the change from surf to isahc that was done in https://github.com/johanhelsing/bevy_web_asset/pull/18 until we can move to a maintained crate that supports all platforms