### PR TITLE
Revision dependencies and fix compile errors for bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 authors = ["Johan Helsing <johanhelsing@gmail.com>"]
-categories = ["network-programming", "game-development", "wasm", "web-programming"]
+categories = [
+  "network-programming",
+  "game-development",
+  "wasm",
+  "web-programming",
+]
 description = "Implementations for http(s) asset sources for Bevy"
 edition = "2021"
 keywords = ["gamedev", "networking", "wasm", "bevy"]
@@ -10,24 +15,28 @@ repository = "https://github.com/johanhelsing/bevy_web_asset"
 version = "0.7.1"
 
 [dependencies]
-bevy = {version = "0.12", default-features = false, features = ["bevy_asset"]}
+bevy = { version = "0.13.0", default-features = false, features = [
+  "bevy_asset",
+] }
 pin-project = "1.1.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-surf = {version = "2.3", default-features = false, features = ["h1-client-rustls"]}
+surf = { version = "2.3", default-features = false, features = [
+  "h1-client-rustls",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = {version = "0.3.22", default-features = false}
-js-sys = {version = "0.3", default-features = false}
-wasm-bindgen = {version = "0.2", default-features = false}
+web-sys = { version = "0.3.67", default-features = false }
+js-sys = { version = "0.3", default-features = false }
+wasm-bindgen = { version = "0.2", default-features = false }
 wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
-bevy = {version = "0.12", default-features = false, features = [
+bevy = { version = "0.13.0", default-features = false, features = [
   "bevy_asset",
   "bevy_core_pipeline",
   "bevy_sprite",
   "png",
   "webgl2",
-  "x11", # GitHub Actions runners don't have libxkbcommon installed, so can't use Wayland
-]}
+  "x11",                # GitHub Actions runners don't have libxkbcommon installed, so can't use Wayland
+] }


### PR DESCRIPTION
Quick PR here to ensure bevy 0.13 support
- Update dependencies in line with bevy 0.13
- Pin web_sys to the same version as bevy 0.13
- Use `.into()` to fix compile errors that surfaced after library upgrades

PS: my formatter seems to have run on the cargo.toml