### PR TITLE
Update to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ repository = "https://github.com/johanhelsing/bevy_web_asset"
 version = "0.8.0"
 
 [dependencies]
-bevy = { version = "0.13.0", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
   "bevy_asset",
 ] }
-pin-project = "1.1.3"
+pin-project = "1.1.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 surf = { version = "2.3", default-features = false, features = [
@@ -32,7 +32,7 @@ wasm-bindgen = { version = "0.2", default-features = false }
 wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
-bevy = { version = "0.13.0", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
   "bevy_asset",
   "bevy_core_pipeline",
   "bevy_sprite",

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ I intend to support the latest bevy release in the `main` branch.
 
 |bevy|bevy_web_asset|
 |----|--------------|
-|0.13|0.8, main     |
+|0.14|0.9, main     |
+|0.13|0.8           |
 |0.12|0.7           |
 |0.9 |0.5           |
 |0.8 |0.4           |

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -167,10 +167,7 @@ impl AssetReader for WebAssetReader {
         get(self.make_meta_uri(path))
     }
 
-    async fn is_directory<'a>(
-        &'a self,
-        _path: &'a Path,
-    ) -> Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, _path: &'a Path) -> Result<bool, AssetReaderError> {
         Ok(false)
     }
 

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -1,5 +1,4 @@
-use bevy::asset::io::PathStream;
-use bevy::utils::BoxedFuture;
+use bevy::{asset::io::PathStream, utils::ConditionalSendFuture};
 use std::path::{Path, PathBuf};
 
 use bevy::asset::io::{AssetReader, AssetReaderError, Reader};
@@ -157,29 +156,29 @@ impl AssetReader for WebAssetReader {
     fn read<'a>(
         &'a self,
         path: &'a Path,
-    ) -> BoxedFuture<'a, Result<Box<Reader<'a>>, AssetReaderError>> {
-        Box::pin(get(self.make_uri(path)))
+    ) -> impl ConditionalSendFuture<Output = Result<Box<Reader<'a>>, AssetReaderError>> {
+        get(self.make_uri(path))
     }
 
     fn read_meta<'a>(
         &'a self,
         path: &'a Path,
-    ) -> BoxedFuture<'a, Result<Box<Reader<'a>>, AssetReaderError>> {
-        Box::pin(get(self.make_meta_uri(path)))
+    ) -> impl ConditionalSendFuture<Output = Result<Box<Reader<'a>>, AssetReaderError>> {
+        get(self.make_meta_uri(path))
     }
 
-    fn is_directory<'a>(
+    async fn is_directory<'a>(
         &'a self,
         _path: &'a Path,
-    ) -> BoxedFuture<'a, Result<bool, AssetReaderError>> {
-        Box::pin(async { Ok(false) })
+    ) -> Result<bool, AssetReaderError> {
+        Ok(false)
     }
 
-    fn read_directory<'a>(
+    async fn read_directory<'a>(
         &'a self,
         path: &'a Path,
-    ) -> BoxedFuture<'a, Result<Box<PathStream>, AssetReaderError>> {
-        Box::pin(async { Err(AssetReaderError::NotFound(self.make_uri(path))) })
+    ) -> Result<Box<PathStream>, AssetReaderError> {
+        Err(AssetReaderError::NotFound(self.make_uri(path)))
     }
 }
 


### PR DESCRIPTION
Updated to Bevy 0.14

Bevy has transitioned to using `async fn` on some traits rather than `BoxedFuture`. Also updated `pin-project` to latest patch release.

See https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#use-async-fn-in-traits-rather-than-boxedfuture