### PR TITLE
Switch to ureq, and store headers/query in a resource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,7 @@ repository = "https://github.com/johanhelsing/bevy_web_asset"
 version = "0.9.0"
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
-  "bevy_asset",
-] }
+bevy = { version = "0.14", default-features = false, features = ["bevy_asset"] }
 pin-project = "1.1.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -26,7 +24,13 @@ surf = { version = "2.3", default-features = false, features = [
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3.67", default-features = false }
+web-sys = { version = "0.3.67", default-features = false, features = [
+  "Window",
+  "Request",
+  "Headers",
+  "RequestInit",
+  "RequestMode",
+] }
 js-sys = { version = "0.3", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false }
 wasm-bindgen-futures = "0.4"
@@ -37,6 +41,7 @@ bevy = { version = "0.14", default-features = false, features = [
   "bevy_core_pipeline",
   "bevy_sprite",
   "png",
+  "jpeg",
   "webgl2",
   "x11",                # GitHub Actions runners don't have libxkbcommon installed, so can't use Wayland
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ bevy = { version = "0.14", default-features = false, features = ["bevy_asset"] }
 pin-project = "1.1.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-surf = { version = "2.3", default-features = false, features = [
-  "h1-client-rustls",
-] }
+ureq = "2.10.1"
+bevy_tasks = { version = "*", features = ["multi_threaded"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3.67", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -55,20 +55,30 @@ commands.spawn(SpriteBundle {
 });
 ```
 
+Supports adding headers and query parameters, specified initially when adding the plugin:
+
+```rust ignore
+WebAssetPlugin::default()
+    .enable_fake_extensions() // for URLs which don't have a file extension, add "..png" which won't be sent
+    .push_header("x-api-key", "somekey") // set a api key for all requests
+    .push_header("Accept", "application/octet-stream") // we want a binary file
+    .push_query("quality", "high"), // this appends ?quality=high to the actual requests
+```
+
 ## Bevy version support
 
 I intend to support the latest bevy release in the `main` branch.
 
-|bevy|bevy_web_asset|
-|----|--------------|
-|0.14|0.9, main     |
-|0.13|0.8           |
-|0.12|0.7           |
-|0.9 |0.5           |
-|0.8 |0.4           |
-|0.7 |0.3           |
-|0.6 |0.2           |
-|0.5 |0.1           |
+| bevy | bevy_web_asset |
+| ---- | -------------- |
+| 0.14 | 0.9, main      |
+| 0.13 | 0.8            |
+| 0.12 | 0.7            |
+| 0.9  | 0.5            |
+| 0.8  | 0.4            |
+| 0.7  | 0.3            |
+| 0.6  | 0.2            |
+| 0.5  | 0.1            |
 
 ## License
 

--- a/examples/web_image.rs
+++ b/examples/web_image.rs
@@ -6,7 +6,7 @@ fn main() {
         .add_plugins((
             // The web asset plugin must be inserted before the `AssetPlugin` so
             // that the AssetPlugin recognizes the new sources.
-            WebAssetPlugin,
+            WebAssetPlugin::default(),
             DefaultPlugins,
         ))
         .add_systems(Startup, setup)

--- a/examples/web_image.rs
+++ b/examples/web_image.rs
@@ -18,7 +18,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn(SpriteBundle {
         // Simply use a url where you would normally use an asset folder relative path
-        texture: asset_server.load("https://s3.johanhelsing.studio/dump/favicon.png"),
+        texture: asset_server
+            .load("https://pixnio.com/free-images/2024/09/30/2024-09-30-09-05-06-960x640.jpg"), // no-attribution pixnio license
         ..default()
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@ mod web_asset_source;
 
 pub use web_asset_plugin::WebAssetPlugin;
 pub use web_asset_source::WebAssetReader;
+pub use web_asset_source::WebAssetReaderData;
+pub use web_asset_source::WebAssetReaderDataInner;

--- a/src/web_asset_plugin.rs
+++ b/src/web_asset_plugin.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashMap};
 
 use crate::web_asset_source::*;
 use bevy::asset::io::AssetSource;
@@ -21,17 +21,73 @@ use bevy::asset::io::AssetSource;
 /// ));
 /// ```
 #[derive(Default)]
-pub struct WebAssetPlugin;
+pub struct WebAssetPlugin {
+    headers: HashMap<String, Vec<String>>,
+    query: HashMap<String, String>,
+    fake_extension: bool,
+}
+
+impl WebAssetPlugin {
+    /// Headers will be passed along with each request
+    pub fn new(headers: HashMap<String, Vec<String>>, query: HashMap<String, String>) -> Self {
+        Self {
+            headers,
+            query,
+            fake_extension: false,
+        }
+    }
+
+    /// Enable "fake extension". This turns "test/example..png" into "test/example", but leaves single dots alone.
+    pub fn enable_fake_extensions(mut self) -> Self {
+        self.fake_extension = true;
+        self
+    }
+
+    /// Push a new header to be sent along every asset load. The same key can be pushed multiple times.
+    pub fn push_header(mut self, key: impl ToString, value: impl ToString) -> Self {
+        self.headers
+            .entry(key.to_string())
+            .or_insert_with(Vec::new)
+            .push(value.to_string());
+        self
+    }
+
+    /// Push a query parameter, which will be appended to the reqeust before its sent
+    pub fn push_query(mut self, key: impl ToString, value: impl ToString) -> Self {
+        self.query.insert(key.to_string(), value.to_string());
+        self
+    }
+}
 
 impl Plugin for WebAssetPlugin {
     fn build(&self, app: &mut App) {
+        let headers = self.headers.clone();
+        let query = self.query.clone();
+        let fake_extension = self.fake_extension;
         app.register_asset_source(
             "http",
-            AssetSource::build().with_reader(|| Box::new(WebAssetReader::Http)),
+            AssetSource::build().with_reader(move || {
+                Box::new(WebAssetReader {
+                    protocol: Protocol::Http,
+                    headers: headers.clone(),
+                    query: query.clone(),
+                    fake_extensions: fake_extension,
+                })
+            }),
         );
+
+        let query = self.query.clone();
+        let headers = self.headers.clone();
         app.register_asset_source(
             "https",
-            AssetSource::build().with_reader(|| Box::new(WebAssetReader::Https)),
+            AssetSource::build().with_reader(move || {
+                Box::new(WebAssetReader {
+                    protocol: Protocol::Https,
+                    headers: headers.clone(),
+                    query: query.clone(),
+                    fake_extensions: fake_extension,
+                })
+            }),
         );
     }
 }

--- a/src/web_asset_plugin.rs
+++ b/src/web_asset_plugin.rs
@@ -1,4 +1,6 @@
-use bevy::{prelude::*, utils::HashMap};
+use std::sync::{Arc, RwLock};
+
+use bevy::prelude::*;
 
 use crate::web_asset_source::*;
 use bevy::asset::io::AssetSource;
@@ -22,30 +24,25 @@ use bevy::asset::io::AssetSource;
 /// ```
 #[derive(Default)]
 pub struct WebAssetPlugin {
-    headers: HashMap<String, Vec<String>>,
-    query: HashMap<String, String>,
-    fake_extension: bool,
+    data: WebAssetReaderDataInner,
 }
 
 impl WebAssetPlugin {
     /// Headers will be passed along with each request
-    pub fn new(headers: HashMap<String, Vec<String>>, query: HashMap<String, String>) -> Self {
-        Self {
-            headers,
-            query,
-            fake_extension: false,
-        }
+    pub fn new(data: WebAssetReaderDataInner) -> Self {
+        Self { data }
     }
 
     /// Enable "fake extension". This turns "test/example..png" into "test/example", but leaves single dots alone.
     pub fn enable_fake_extensions(mut self) -> Self {
-        self.fake_extension = true;
+        self.data.fake_extensions = true;
         self
     }
 
     /// Push a new header to be sent along every asset load. The same key can be pushed multiple times.
     pub fn push_header(mut self, key: impl ToString, value: impl ToString) -> Self {
-        self.headers
+        self.data
+            .headers
             .entry(key.to_string())
             .or_insert_with(Vec::new)
             .push(value.to_string());
@@ -54,38 +51,39 @@ impl WebAssetPlugin {
 
     /// Push a query parameter, which will be appended to the reqeust before its sent
     pub fn push_query(mut self, key: impl ToString, value: impl ToString) -> Self {
-        self.query.insert(key.to_string(), value.to_string());
+        self.data.query.insert(key.to_string(), value.to_string());
         self
     }
 }
 
 impl Plugin for WebAssetPlugin {
     fn build(&self, app: &mut App) {
-        let headers = self.headers.clone();
-        let query = self.query.clone();
-        let fake_extension = self.fake_extension;
+        app.insert_resource(WebAssetReaderData {
+            data: Arc::new(RwLock::new(self.data.clone())),
+        });
+
+        // seems to be the best way to resolve borrow/move issues here with the closures
+        let (weak_a, weak_b) = {
+            let res = app.world().resource::<WebAssetReaderData>();
+            (Arc::downgrade(&res.data), Arc::downgrade(&res.data))
+        };
+
         app.register_asset_source(
             "http",
             AssetSource::build().with_reader(move || {
                 Box::new(WebAssetReader {
                     protocol: Protocol::Http,
-                    headers: headers.clone(),
-                    query: query.clone(),
-                    fake_extensions: fake_extension,
+                    shared: weak_a.upgrade().unwrap(),
                 })
             }),
         );
 
-        let query = self.query.clone();
-        let headers = self.headers.clone();
         app.register_asset_source(
             "https",
             AssetSource::build().with_reader(move || {
                 Box::new(WebAssetReader {
                     protocol: Protocol::Https,
-                    headers: headers.clone(),
-                    query: query.clone(),
-                    fake_extensions: fake_extension,
+                    shared: weak_b.upgrade().unwrap(),
                 })
             }),
         );

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -22,7 +22,42 @@ pub enum Protocol {
 /// Resource which stores headers, query and other settings for [`WebAssetReader`].
 #[derive(Resource, Debug, Default)]
 pub struct WebAssetReaderData {
-    pub data: Arc<RwLock<WebAssetReaderDataInner>>,
+    pub(crate) data: Arc<RwLock<WebAssetReaderDataInner>>,
+}
+
+impl WebAssetReaderData {
+    /// When true, this feature turns "test/example..png" into "test/example" while sending the request, but leaves individual dots alone.
+    pub fn set_fake_extensions(&self, state: bool) {
+        let mut w = self.data.write().unwrap();
+        w.fake_extensions = state;
+    }
+
+    /// Push a new header to be sent along every asset load. The same key can be pushed multiple times.
+    pub fn push_header(&self, key: impl ToString, value: impl ToString) {
+        let mut w = self.data.write().unwrap();
+        w.headers
+            .entry(key.to_string())
+            .or_insert_with(Vec::new)
+            .push(value.to_string());
+    }
+
+    /// Remove all headers
+    pub fn clear_headers(&self) {
+        let mut w = self.data.write().unwrap();
+        w.headers.clear();
+    }
+
+    /// Push a query parameter, which will be appended to the reqeust before its sent
+    pub fn push_query(&self, key: impl ToString, value: impl ToString) {
+        let mut w = self.data.write().unwrap();
+        w.query.insert(key.to_string(), value.to_string());
+    }
+
+    /// Remove all query params
+    pub fn clear_query(&self) {
+        let mut w = self.data.write().unwrap();
+        w.query.clear();
+    }
 }
 
 /// Struct which stores headers, query and other settings for [`WebAssetReader`].

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn make_http_uri_no_fake() {
         assert_eq!(
-            new_reader(Protocol::Http, true)
+            new_reader(Protocol::Http, false)
                 .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon..png"))
                 .to_str()
                 .unwrap(),

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -1,32 +1,51 @@
 use bevy::{
     asset::io::PathStream,
+    prelude::*,
     utils::{ConditionalSendFuture, HashMap},
 };
 use std::{
-    ffi::OsString,
     path::{Path, PathBuf},
+    sync::{Arc, RwLock},
 };
 
 use bevy::asset::io::{AssetReader, AssetReaderError, Reader};
 
 /// Which protocol to use
+#[derive(Debug)]
 pub enum Protocol {
-    /// Unencrypted connections.
-    Http,
     /// Use TLS for setting up connections.
     Https,
+    /// Unencrypted connections.
+    Http,
 }
 
-/// Treats paths as urls to load assets from.
-pub struct WebAssetReader {
-    /// The protocol whith which the request is sent
-    pub protocol: Protocol,
+/// Resource which stores headers, query and other settings for [`WebAssetReader`].
+#[derive(Resource, Debug, Default)]
+pub struct WebAssetReaderData {
+    pub data: Arc<RwLock<WebAssetReaderDataInner>>,
+}
+
+/// Struct which stores headers, query and other settings for [`WebAssetReader`].
+///
+/// The asset reader stores this using a `Weak<RwLock<>>` so it may access changes done to the [`WebAssetReaderData`] Resource owning this.
+#[derive(Debug, Default, Clone)]
+pub struct WebAssetReaderDataInner {
     /// Headers will be passed along with each request
     pub headers: HashMap<String, Vec<String>>,
     /// Query parameters will be passed along with each request
     pub query: HashMap<String, String>,
     /// Fake extensions are those with 2 dots. They will be removed before sending the request.
     pub fake_extensions: bool,
+}
+
+/// Treats paths as urls to load assets from.
+pub struct WebAssetReader {
+    /// The protocol whith which the request is sent.
+    /// This is usually set by the plugin during [`bevy::app::App::register_asset_source`]
+    /// to correspond with the the [`bevy::asset::io::AssetSourceId`] set for this
+    pub protocol: Protocol,
+    /// Shared
+    pub shared: Arc<RwLock<WebAssetReaderDataInner>>,
 }
 
 fn strip_double_extension(path: &mut PathBuf) -> Option<()> {
@@ -43,17 +62,13 @@ fn strip_double_extension(path: &mut PathBuf) -> Option<()> {
 }
 
 impl WebAssetReader {
-    fn make_header_iter(&self) -> impl Iterator<Item = (&str, &[String])> {
-        self.headers.iter().map(|(k, v)| (k.as_str(), v.as_slice()))
-    }
-
     fn make_uri(&self, path: &Path) -> PathBuf {
         let mut buf = PathBuf::from(match self.protocol {
             Protocol::Http => "http://",
             Protocol::Https => "https://",
         })
         .join(path);
-        if self.fake_extensions {
+        if self.shared.read().unwrap().fake_extensions {
             strip_double_extension(&mut buf);
         }
         buf
@@ -61,7 +76,8 @@ impl WebAssetReader {
 
     fn make_uri_query(&self, path: &Path) -> PathBuf {
         let mut buf = self.make_uri(path);
-        let mut query = self.query.iter();
+        let shared_guard = self.shared.read().unwrap();
+        let mut query = shared_guard.query.iter();
         let mut query_string = String::new();
         if let Some((query_k, val)) = query.next() {
             query_string += &format!("?{query_k}={val}");
@@ -70,7 +86,9 @@ impl WebAssetReader {
         for (query_k, val) in query {
             query_string += &format!("&{query_k}={val}");
         }
-        buf.push(query_string);
+        if query_string.len() > 0 {
+            buf.push(query_string);
+        }
         buf
     }
 
@@ -88,7 +106,7 @@ impl WebAssetReader {
 #[cfg(target_arch = "wasm32")]
 async fn get<'a>(
     path: PathBuf,
-    headers: impl Iterator<Item = (&str, &[String])>,
+    shared: Arc<RwLock<WebAssetReaderDataInner>>,
 ) -> Result<Box<Reader<'a>>, AssetReaderError> {
     use bevy::asset::io::VecReader;
     use js_sys::Uint8Array;
@@ -118,7 +136,13 @@ async fn get<'a>(
     init.set_mode(RequestMode::Cors);
     let request = Request::new_with_str_and_init(path.to_str().unwrap(), &init).unwrap();
     let request_headers = request.headers();
-    for (header_name, header_values) in headers {
+    for (header_name, header_values) in shared
+        .read()
+        .unwrap()
+        .headers
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_slice()))
+    {
         for header_value in header_values {
             request_headers
                 .append(header_name, header_value.as_str())
@@ -152,100 +176,73 @@ async fn get<'a>(
 #[cfg(not(target_arch = "wasm32"))]
 async fn get<'a>(
     path: PathBuf,
-    headers: impl Iterator<Item = (&str, &[String])>,
+    shared: Arc<RwLock<WebAssetReaderDataInner>>,
 ) -> Result<Box<Reader<'a>>, AssetReaderError> {
-    use std::future::Future;
     use std::io;
-    use std::pin::Pin;
-    use std::str::FromStr;
-    use std::task::{Context, Poll};
+    use std::time::Duration;
 
     use bevy::asset::io::VecReader;
-    use surf::http::headers::{HeaderValue, HeaderValues};
-    use surf::StatusCode;
+    use bevy::tasks::AsyncComputeTaskPool;
 
-    #[pin_project::pin_project]
-    struct ContinuousPoll<T>(#[pin] T);
-
-    impl<T: Future> Future for ContinuousPoll<T> {
-        type Output = T::Output;
-
-        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            // Always wake - blocks on single threaded executor.
-            cx.waker().wake_by_ref();
-
-            self.project().0.poll(cx)
-        }
-    }
-
-    let str_path = path
-        .to_str()
-        .ok_or_else(|| {
-            AssetReaderError::Io(
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("non-utf8 path: {}", path.display()),
-                )
-                .into(),
-            )
-        })?
-        .to_string();
-
-    let mut request = surf::get(str_path);
-
-    // From headers iter to surf headers
-    for (header_name, header_values) in headers {
-        let hvs: Result<HeaderValues, _> = header_values
-            .iter()
-            .map(|f| {
-                HeaderValue::from_str(f).map_err(|_| {
-                    AssetReaderError::Io(
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("Header values for {} should be ASCII", header_name),
-                        )
-                        .into(),
-                    )
-                })
-            })
-            .collect();
-        request = request.header(header_name, &hvs?);
-    }
-
-    let mut response = ContinuousPoll(request).await.map_err(|err| {
+    let str_path = path.to_str().ok_or_else(|| {
         AssetReaderError::Io(
             io::Error::new(
                 io::ErrorKind::Other,
-                format!(
-                    "unexpected status code {} while loading {}: {}",
-                    err.status(),
-                    path.display(),
-                    err.into_inner(),
-                ),
+                format!("non-utf8 path: {}", path.display()),
             )
             .into(),
         )
     })?;
 
-    match response.status() {
-        StatusCode::Ok => Ok(Box::new(VecReader::new(
-            ContinuousPoll(response.body_bytes())
-                .await
-                .map_err(|_| AssetReaderError::NotFound(path.to_path_buf()))?,
-        )) as _),
-        StatusCode::NotFound => Err(AssetReaderError::NotFound(path)),
-        code => Err(AssetReaderError::Io(
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!(
-                    "unexpected status code {} while loading {}",
-                    code,
-                    path.display()
-                ),
-            )
-            .into(),
-        )),
+    let mut request = ureq::get(str_path);
+
+    // From headers iter to surf headers
+    for (header_name, header_values) in shared
+        .read()
+        .unwrap()
+        .headers
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_slice()))
+    {
+        for val in header_values {
+            request = request.set(header_name, val);
+        }
     }
+
+    let pool = AsyncComputeTaskPool::get();
+    let blocking_task: bevy_tasks::Task<Result<_, AssetReaderError>> = pool.spawn(async move {
+        let response = request.call().map_err(|err| {
+            if let ureq::Error::Status(404, _) = err {
+                AssetReaderError::NotFound(path.clone())
+            } else {
+                AssetReaderError::Io(
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("unexpected error while loading {}: {}", path.display(), err),
+                    )
+                    .into(),
+                )
+            }
+        })?;
+
+        dbg!(&response);
+        let mut buf = vec![];
+        let mut reader = response.into_reader();
+        reader.read_to_end(&mut buf).map_err(|err| {
+            AssetReaderError::Io(
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("unexpected error while loading {}: {}", path.display(), err,),
+                )
+                .into(),
+            )
+        })?;
+        Ok(buf)
+    });
+
+    let result = blocking_task.await?;
+    dbg!(result.len());
+    Ok(Box::new(VecReader::new(result)))
 }
 
 impl AssetReader for WebAssetReader {
@@ -253,12 +250,12 @@ impl AssetReader for WebAssetReader {
         &'a self,
         path: &'a Path,
     ) -> impl ConditionalSendFuture<Output = Result<Box<Reader<'a>>, AssetReaderError>> {
-        get(self.make_uri_query(path), self.make_header_iter())
+        get(self.make_uri_query(path), self.shared.clone())
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
         match self.make_meta_uri(path) {
-            Some(uri) => get(uri, self.make_header_iter()).await,
+            Some(uri) => get(uri, self.shared.clone()).await,
             None => Err(AssetReaderError::NotFound(
                 "source path has no extension".into(),
             )),
@@ -283,18 +280,34 @@ mod tests {
 
     use super::*;
 
+    fn new_reader(protocol: Protocol, fake_extensions: bool) -> WebAssetReader {
+        WebAssetReader {
+            protocol,
+            shared: Arc::new(RwLock::new(WebAssetReaderDataInner {
+                fake_extensions,
+                ..default()
+            })),
+        }
+    }
+
+    #[test]
+    fn make_http_uri_no_fake() {
+        assert_eq!(
+            new_reader(Protocol::Http, true)
+                .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon..png"))
+                .to_str()
+                .unwrap(),
+            "http://s3.johanhelsing.studio/dump/favicon..png"
+        );
+    }
+
     #[test]
     fn make_http_uri() {
         assert_eq!(
-            WebAssetReader {
-                protocol: Protocol::Http,
-                headers: default(),
-                query: default(),
-                fake_extensions: true
-            }
-            .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
-            .to_str()
-            .unwrap(),
+            new_reader(Protocol::Http, true)
+                .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
+                .to_str()
+                .unwrap(),
             "http://s3.johanhelsing.studio/dump/favicon.png"
         );
     }
@@ -302,15 +315,10 @@ mod tests {
     #[test]
     fn make_http_uri_strip_fake() {
         assert_eq!(
-            WebAssetReader {
-                protocol: Protocol::Http,
-                headers: default(),
-                query: default(),
-                fake_extensions: true
-            }
-            .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon..png"))
-            .to_str()
-            .unwrap(),
+            new_reader(Protocol::Http, true)
+                .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon..png"))
+                .to_str()
+                .unwrap(),
             "http://s3.johanhelsing.studio/dump/favicon"
         );
     }
@@ -318,15 +326,10 @@ mod tests {
     #[test]
     fn make_https_uri() {
         assert_eq!(
-            WebAssetReader {
-                protocol: Protocol::Https,
-                headers: default(),
-                query: default(),
-                fake_extensions: true,
-            }
-            .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
-            .to_str()
-            .unwrap(),
+            new_reader(Protocol::Https, true)
+                .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
+                .to_str()
+                .unwrap(),
             "https://s3.johanhelsing.studio/dump/favicon.png"
         );
     }
@@ -334,16 +337,11 @@ mod tests {
     #[test]
     fn make_http_meta_uri() {
         assert_eq!(
-            WebAssetReader {
-                protocol: Protocol::Http,
-                headers: default(),
-                query: default(),
-                fake_extensions: true,
-            }
-            .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
-            .expect("cannot create meta uri")
-            .to_str()
-            .unwrap(),
+            new_reader(Protocol::Http, true)
+                .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
+                .expect("cannot create meta uri")
+                .to_str()
+                .unwrap(),
             "http://s3.johanhelsing.studio/dump/favicon.png.meta"
         );
     }
@@ -351,16 +349,11 @@ mod tests {
     #[test]
     fn make_http_meta_uri_strip_fake() {
         assert_eq!(
-            WebAssetReader {
-                protocol: Protocol::Http,
-                headers: default(),
-                query: default(),
-                fake_extensions: true,
-            }
-            .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon..png"))
-            .expect("cannot create meta uri")
-            .to_str()
-            .unwrap(),
+            new_reader(Protocol::Http, true)
+                .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon..png"))
+                .expect("cannot create meta uri")
+                .to_str()
+                .unwrap(),
             "http://s3.johanhelsing.studio/dump/favicon.meta"
         );
     }
@@ -368,16 +361,11 @@ mod tests {
     #[test]
     fn make_https_meta_uri() {
         assert_eq!(
-            WebAssetReader {
-                protocol: Protocol::Https,
-                headers: default(),
-                query: default(),
-                fake_extensions: true,
-            }
-            .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
-            .expect("cannot create meta uri")
-            .to_str()
-            .unwrap(),
+            new_reader(Protocol::Https, true)
+                .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
+                .expect("cannot create meta uri")
+                .to_str()
+                .unwrap(),
             "https://s3.johanhelsing.studio/dump/favicon.png.meta"
         );
     }
@@ -385,13 +373,8 @@ mod tests {
     #[test]
     fn make_https_without_extension_meta_uri() {
         assert_eq!(
-            WebAssetReader {
-                protocol: Protocol::Https,
-                headers: default(),
-                query: default(),
-                fake_extensions: true,
-            }
-            .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon")),
+            new_reader(Protocol::Https, true)
+                .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon")),
             None
         );
     }

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -179,7 +179,6 @@ async fn get<'a>(
     shared: Arc<RwLock<WebAssetReaderDataInner>>,
 ) -> Result<Box<Reader<'a>>, AssetReaderError> {
     use std::io;
-    use std::time::Duration;
 
     use bevy::asset::io::VecReader;
     use bevy::tasks::AsyncComputeTaskPool;
@@ -225,7 +224,6 @@ async fn get<'a>(
             }
         })?;
 
-        dbg!(&response);
         let mut buf = vec![];
         let mut reader = response.into_reader();
         reader.read_to_end(&mut buf).map_err(|err| {
@@ -241,7 +239,6 @@ async fn get<'a>(
     });
 
     let result = blocking_task.await?;
-    dbg!(result.len());
     Ok(Box::new(VecReader::new(result)))
 }
 

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -1,42 +1,100 @@
-use bevy::{asset::io::PathStream, utils::ConditionalSendFuture};
-use std::path::{Path, PathBuf};
+use bevy::{
+    asset::io::PathStream,
+    utils::{ConditionalSendFuture, HashMap},
+};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 
 use bevy::asset::io::{AssetReader, AssetReaderError, Reader};
 
-/// Treats paths as urls to load assets from.
-pub enum WebAssetReader {
+/// Which protocol to use
+pub enum Protocol {
     /// Unencrypted connections.
     Http,
     /// Use TLS for setting up connections.
     Https,
 }
 
+/// Treats paths as urls to load assets from.
+pub struct WebAssetReader {
+    /// The protocol whith which the request is sent
+    pub protocol: Protocol,
+    /// Headers will be passed along with each request
+    pub headers: HashMap<String, Vec<String>>,
+    /// Query parameters will be passed along with each request
+    pub query: HashMap<String, String>,
+    /// Fake extensions are those with 2 dots. They will be removed before sending the request.
+    pub fake_extensions: bool,
+}
+
+fn strip_double_extension(path: &mut PathBuf) -> Option<()> {
+    let fname = path.file_name()?.to_str()?;
+    let ext_start = fname.len() - path.extension()?.len();
+
+    if &fname[ext_start - 2..ext_start] == ".." {
+        path.set_extension("");
+        path.set_extension("");
+        Some(())
+    } else {
+        Some(())
+    }
+}
+
 impl WebAssetReader {
+    fn make_header_iter(&self) -> impl Iterator<Item = (&str, &[String])> {
+        self.headers.iter().map(|(k, v)| (k.as_str(), v.as_slice()))
+    }
+
     fn make_uri(&self, path: &Path) -> PathBuf {
-        PathBuf::from(match self {
-            Self::Http => "http://",
-            Self::Https => "https://",
+        let mut buf = PathBuf::from(match self.protocol {
+            Protocol::Http => "http://",
+            Protocol::Https => "https://",
         })
-        .join(path)
+        .join(path);
+        if self.fake_extensions {
+            strip_double_extension(&mut buf);
+        }
+        buf
+    }
+
+    fn make_uri_query(&self, path: &Path) -> PathBuf {
+        let mut buf = self.make_uri(path);
+        let mut query = self.query.iter();
+        let mut query_string = String::new();
+        if let Some((query_k, val)) = query.next() {
+            query_string += &format!("?{query_k}={val}");
+        }
+
+        for (query_k, val) in query {
+            query_string += &format!("&{query_k}={val}");
+        }
+        buf.push(query_string);
+        buf
     }
 
     /// See [bevy::asset::io::get_meta_path]
     fn make_meta_uri(&self, path: &Path) -> Option<PathBuf> {
+        path.extension()?;
         let mut uri = self.make_uri(path);
-        let mut extension = path.extension()?.to_os_string();
-        extension.push(".meta");
-        uri.set_extension(extension);
+        let mut fname = uri.file_name()?.to_os_string();
+        fname.push(".meta");
+        uri.set_file_name(fname);
         Some(uri)
     }
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn get<'a>(path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
+async fn get<'a>(
+    path: PathBuf,
+    headers: impl Iterator<Item = (&str, &[String])>,
+) -> Result<Box<Reader<'a>>, AssetReaderError> {
     use bevy::asset::io::VecReader;
     use js_sys::Uint8Array;
     use wasm_bindgen::JsCast;
     use wasm_bindgen_futures::JsFuture;
-    use web_sys::Response;
+    use web_sys::{Request, RequestInit, RequestMode, Response};
 
     fn js_value_to_err<'a>(
         context: &'a str,
@@ -56,7 +114,18 @@ async fn get<'a>(path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
     }
 
     let window = web_sys::window().unwrap();
-    let resp_value = JsFuture::from(window.fetch_with_str(path.to_str().unwrap()))
+    let mut init = RequestInit::new();
+    init.set_mode(RequestMode::Cors);
+    let request = Request::new_with_str_and_init(path.to_str().unwrap(), &init).unwrap();
+    let request_headers = request.headers();
+    for (header_name, header_values) in headers {
+        for header_value in header_values {
+            request_headers
+                .append(header_name, header_value.as_str())
+                .map_err(js_value_to_err("append header"))?;
+        }
+    }
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
         .await
         .map_err(js_value_to_err("fetch path"))?;
     let resp = resp_value
@@ -81,13 +150,18 @@ async fn get<'a>(path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn get<'a>(path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
+async fn get<'a>(
+    path: PathBuf,
+    headers: impl Iterator<Item = (&str, &[String])>,
+) -> Result<Box<Reader<'a>>, AssetReaderError> {
     use std::future::Future;
     use std::io;
     use std::pin::Pin;
+    use std::str::FromStr;
     use std::task::{Context, Poll};
 
     use bevy::asset::io::VecReader;
+    use surf::http::headers::{HeaderValue, HeaderValues};
     use surf::StatusCode;
 
     #[pin_project::pin_project]
@@ -104,16 +178,41 @@ async fn get<'a>(path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
         }
     }
 
-    let str_path = path.to_str().ok_or_else(|| {
-        AssetReaderError::Io(
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("non-utf8 path: {}", path.display()),
+    let str_path = path
+        .to_str()
+        .ok_or_else(|| {
+            AssetReaderError::Io(
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("non-utf8 path: {}", path.display()),
+                )
+                .into(),
             )
-            .into(),
-        )
-    })?;
-    let mut response = ContinuousPoll(surf::get(str_path)).await.map_err(|err| {
+        })?
+        .to_string();
+
+    let mut request = surf::get(str_path);
+
+    // From headers iter to surf headers
+    for (header_name, header_values) in headers {
+        let hvs: Result<HeaderValues, _> = header_values
+            .iter()
+            .map(|f| {
+                HeaderValue::from_str(f).map_err(|_| {
+                    AssetReaderError::Io(
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("Header values for {} should be ASCII", header_name),
+                        )
+                        .into(),
+                    )
+                })
+            })
+            .collect();
+        request = request.header(header_name, &hvs?);
+    }
+
+    let mut response = ContinuousPoll(request).await.map_err(|err| {
         AssetReaderError::Io(
             io::Error::new(
                 io::ErrorKind::Other,
@@ -154,12 +253,12 @@ impl AssetReader for WebAssetReader {
         &'a self,
         path: &'a Path,
     ) -> impl ConditionalSendFuture<Output = Result<Box<Reader<'a>>, AssetReaderError>> {
-        get(self.make_uri(path))
+        get(self.make_uri_query(path), self.make_header_iter())
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
         match self.make_meta_uri(path) {
-            Some(uri) => get(uri).await,
+            Some(uri) => get(uri, self.make_header_iter()).await,
             None => Err(AssetReaderError::NotFound(
                 "source path has no extension".into(),
             )),
@@ -180,26 +279,54 @@ impl AssetReader for WebAssetReader {
 
 #[cfg(test)]
 mod tests {
+    use bevy::utils::default;
+
     use super::*;
 
     #[test]
     fn make_http_uri() {
         assert_eq!(
-            WebAssetReader::Http
-                .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
-                .to_str()
-                .unwrap(),
+            WebAssetReader {
+                protocol: Protocol::Http,
+                headers: default(),
+                query: default(),
+                fake_extensions: true
+            }
+            .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
+            .to_str()
+            .unwrap(),
             "http://s3.johanhelsing.studio/dump/favicon.png"
+        );
+    }
+
+    #[test]
+    fn make_http_uri_strip_fake() {
+        assert_eq!(
+            WebAssetReader {
+                protocol: Protocol::Http,
+                headers: default(),
+                query: default(),
+                fake_extensions: true
+            }
+            .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon..png"))
+            .to_str()
+            .unwrap(),
+            "http://s3.johanhelsing.studio/dump/favicon"
         );
     }
 
     #[test]
     fn make_https_uri() {
         assert_eq!(
-            WebAssetReader::Https
-                .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
-                .to_str()
-                .unwrap(),
+            WebAssetReader {
+                protocol: Protocol::Https,
+                headers: default(),
+                query: default(),
+                fake_extensions: true,
+            }
+            .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
+            .to_str()
+            .unwrap(),
             "https://s3.johanhelsing.studio/dump/favicon.png"
         );
     }
@@ -207,23 +334,50 @@ mod tests {
     #[test]
     fn make_http_meta_uri() {
         assert_eq!(
-            WebAssetReader::Http
-                .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
-                .expect("cannot create meta uri")
-                .to_str()
-                .unwrap(),
+            WebAssetReader {
+                protocol: Protocol::Http,
+                headers: default(),
+                query: default(),
+                fake_extensions: true,
+            }
+            .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
+            .expect("cannot create meta uri")
+            .to_str()
+            .unwrap(),
             "http://s3.johanhelsing.studio/dump/favicon.png.meta"
+        );
+    }
+
+    #[test]
+    fn make_http_meta_uri_strip_fake() {
+        assert_eq!(
+            WebAssetReader {
+                protocol: Protocol::Http,
+                headers: default(),
+                query: default(),
+                fake_extensions: true,
+            }
+            .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon..png"))
+            .expect("cannot create meta uri")
+            .to_str()
+            .unwrap(),
+            "http://s3.johanhelsing.studio/dump/favicon.meta"
         );
     }
 
     #[test]
     fn make_https_meta_uri() {
         assert_eq!(
-            WebAssetReader::Https
-                .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
-                .expect("cannot create meta uri")
-                .to_str()
-                .unwrap(),
+            WebAssetReader {
+                protocol: Protocol::Https,
+                headers: default(),
+                query: default(),
+                fake_extensions: true,
+            }
+            .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
+            .expect("cannot create meta uri")
+            .to_str()
+            .unwrap(),
             "https://s3.johanhelsing.studio/dump/favicon.png.meta"
         );
     }
@@ -231,7 +385,13 @@ mod tests {
     #[test]
     fn make_https_without_extension_meta_uri() {
         assert_eq!(
-            WebAssetReader::Https.make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon")),
+            WebAssetReader {
+                protocol: Protocol::Https,
+                headers: default(),
+                query: default(),
+                fake_extensions: true,
+            }
+            .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon")),
             None
         );
     }


### PR DESCRIPTION
This PR switches the client to ureq using a AsyncComputeTaskPool to make requests non-blocking.

Its a optional follow-up to my PR:
- #35 

requires bevy_tasks with `multi_threaded` feature, otherwise Task isn't awaitable. Not sure if this leads to duplication in the dependency tree, or if bevy_tasks from the main bevy version is re-used. Could probably work around this with come cfg() magic looking at which bevy_task feature is enabled.

other than this it also moves headers/query-params into a Resource which shares them with the AssetReaders using a `Arc<RwLock<>>`. This allows the user to set/clear headers/query-params.

I've tested all features locally.