### PR TITLE
feat: bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ bevy = { version = "0.15", default-features = false, features = [
 ] }
 pin-project = "1.1.5"
 
+[features]
+default = ["redirect"]
+redirect = []  # enables surf::middleware::Redirect
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 surf = { version = "2.3", default-features = false, features = [
   "h1-client-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["gamedev", "networking", "wasm", "bevy"]
 license = "MIT OR Apache-2.0"
 name = "bevy_web_asset"
 repository = "https://github.com/johanhelsing/bevy_web_asset"
-version = "0.9.0"
+version = "0.10.0"
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
   "bevy_asset",
 ] }
 pin-project = "1.1.5"
@@ -32,10 +32,11 @@ wasm-bindgen = { version = "0.2", default-features = false }
 wasm-bindgen-futures = "0.4"
 
 [dev-dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
   "bevy_asset",
   "bevy_core_pipeline",
   "bevy_sprite",
+  "bevy_window",        # https://github.com/bevyengine/bevy/issues/16568
   "png",
   "webgl2",
   "x11",                # GitHub Actions runners don't have libxkbcommon installed, so can't use Wayland

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ I intend to support the latest bevy release in the `main` branch.
 
 |bevy|bevy_web_asset|
 |----|--------------|
-|0.14|0.9, main     |
+|0.15|0.10, main    |
+|0.14|0.9,          |
 |0.13|0.8           |
 |0.12|0.7           |
 |0.9 |0.5           |

--- a/examples/web_image.rs
+++ b/examples/web_image.rs
@@ -14,11 +14,9 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
 
-    commands.spawn(SpriteBundle {
-        // Simply use a url where you would normally use an asset folder relative path
-        texture: asset_server.load("https://s3.johanhelsing.studio/dump/favicon.png"),
-        ..default()
-    });
+    commands.spawn(
+        Sprite::from_image(asset_server.load("https://s3.johanhelsing.studio/dump/favicon.png"))
+    );
 }

--- a/examples/web_image.rs
+++ b/examples/web_image.rs
@@ -17,6 +17,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2d::default());
 
     commands.spawn(Sprite::from_image(
-        asset_server.load("https://s3.johanhelsing.studio/dump/favicon.png")
+        asset_server.load("https://s3.johanhelsing.studio/dump/favicon.png"),
     ));
 }

--- a/examples/web_image.rs
+++ b/examples/web_image.rs
@@ -16,7 +16,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2d::default());
 
-    commands.spawn(
-        Sprite::from_image(asset_server.load("https://s3.johanhelsing.studio/dump/favicon.png"))
-    );
+    commands.spawn(Sprite::from_image(
+        asset_server.load("https://s3.johanhelsing.studio/dump/favicon.png")
+    ));
 }

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -114,7 +114,12 @@ async fn get<'a>(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
         )
     })?;
 
+    #[cfg(not(feature = "redirect"))]
     let client = surf::Client::new();
+
+    #[cfg(feature = "redirect")]
+    let client = surf::Client::new().with(surf::middleware::Redirect::default());
+
     let mut response = ContinuousPoll(client.get(str_path)).await.map_err(|err| {
         AssetReaderError::Io(
             io::Error::new(


### PR DESCRIPTION
- fixes surf native example

if loading assets without co-located bevy asset `.meta` files, disable meta loading:
```rust
    App::new()
        .add_plugins((
            // The web asset plugin must be inserted before the `AssetPlugin` so
            // that the AssetPlugin recognizes the new sources.
            WebAssetPlugin,
            DefaultPlugins.set(AssetPlugin {
                meta_check: bevy::asset::AssetMetaCheck::Never,
                ..default()
            }),
        ))
        .add_systems(Startup, setup)
        .run();
```