### PR TITLE
Fix compilation error for wasm target

### DIFF
--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -31,7 +31,7 @@ impl WebAssetReader {
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn get<'a>(path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
+async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
     use bevy::asset::io::VecReader;
     use js_sys::Uint8Array;
     use wasm_bindgen::JsCast;
@@ -66,7 +66,7 @@ async fn get<'a>(path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
         200 => {
             let data = JsFuture::from(resp.array_buffer().unwrap()).await.unwrap();
             let bytes = Uint8Array::new(&data).to_vec();
-            let reader: Box<Reader> = Box::new(VecReader::new(bytes));
+            let reader: Box<dyn Reader> = Box::new(VecReader::new(bytes));
             Ok(reader)
         }
         404 => Err(AssetReaderError::NotFound(path)),


### PR DESCRIPTION
I encountered this error when building for wasm32-unknown-unknown:
```
error[E0782]: trait objects must include the `dyn` keyword
```

It looks like in #38 the `Box<Reader<'a>` was changed to `Box<dyn Reader>` only for not-wasm32, so this PR makes the same changes for wasm32.