### PR TITLE
Implements caching online resources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,13 @@ bevy = { version = "0.15", default-features = false, features = [
   "bevy_asset",
 ] }
 pin-project = "1.1.5"
+directories = {version = "5.0.1", optional = true}
+slug = {version = "0.1.6", optional = true}
 
 [features]
 default = ["redirect"]
 redirect = []  # enables surf::middleware::Redirect
+cache_asset = ["directories", "slug"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 surf = { version = "2.3", default-features = false, features = [

--- a/examples/web_image.rs
+++ b/examples/web_image.rs
@@ -6,7 +6,7 @@ fn main() {
         .add_plugins((
             // The web asset plugin must be inserted before the `AssetPlugin` so
             // that the AssetPlugin recognizes the new sources.
-            WebAssetPlugin,
+            WebAssetPlugin::default(),
             DefaultPlugins,
         ))
         .add_systems(Startup, setup)

--- a/src/web_asset_plugin.rs
+++ b/src/web_asset_plugin.rs
@@ -21,17 +21,36 @@ use bevy::asset::io::AssetSource;
 /// ));
 /// ```
 #[derive(Default)]
-pub struct WebAssetPlugin;
+pub struct WebAssetPlugin {
+    /// Whether to cache the loaded resources.
+    pub cache_resource: bool,
+    /// Whether to reject meta requests.
+    pub reject_meta_request: bool,
+}
 
 impl Plugin for WebAssetPlugin {
     fn build(&self, app: &mut App) {
+        let cache_resource = self.cache_resource;
+        let reject_meta_request = self.reject_meta_request;
         app.register_asset_source(
             "http",
-            AssetSource::build().with_reader(|| Box::new(WebAssetReader::Http)),
+            AssetSource::build().with_reader(move || {
+                Box::new(WebAssetReader {
+                    cache_resource,
+                    reject_meta_request,
+                    connection: WebAssetReaderConnection::Http,
+                })
+            }),
         );
         app.register_asset_source(
             "https",
-            AssetSource::build().with_reader(|| Box::new(WebAssetReader::Https)),
+            AssetSource::build().with_reader(move || {
+                Box::new(WebAssetReader {
+                    cache_resource,
+                    reject_meta_request,
+                    connection: WebAssetReaderConnection::Https,
+                })
+            }),
         );
     }
 }

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -85,7 +85,7 @@ impl WebAssetReaderConnection {
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn get<'a>(path: PathBuf, _: Option<PathBuf>) -> Result<Box<Reader<'a>>, AssetReaderError> {
+async fn get(path: PathBuf, _: Option<PathBuf>) -> Result<Box<dyn Reader>, AssetReaderError> {
     use bevy::asset::io::VecReader;
     use js_sys::Uint8Array;
     use wasm_bindgen::JsCast;
@@ -135,7 +135,7 @@ async fn get<'a>(path: PathBuf, _: Option<PathBuf>) -> Result<Box<Reader<'a>>, A
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn get<'a>(
+async fn get(
     path: PathBuf,
     cache_path: Option<PathBuf>,
 ) -> Result<Box<dyn Reader>, AssetReaderError> {

--- a/src/web_asset_source.rs
+++ b/src/web_asset_source.rs
@@ -4,18 +4,72 @@ use std::path::{Path, PathBuf};
 use bevy::asset::io::{AssetReader, AssetReaderError, Reader};
 
 /// Treats paths as urls to load assets from.
-pub enum WebAssetReader {
+pub struct WebAssetReader {
+    /// Option to cache resource.
+    pub cache_resource: bool,
+    /// Option to disable meta request (some server returns 500 if too many invalid
+    /// requests are sent, to prevent bot).
+    pub reject_meta_request: bool,
+    /// Connection type.
+    pub connection: WebAssetReaderConnection,
+}
+
+impl Default for WebAssetReader {
+    fn default() -> Self {
+        Self {
+            cache_resource: false,
+            reject_meta_request: false,
+            connection: WebAssetReaderConnection::Https,
+        }
+    }
+}
+
+impl WebAssetReader {
+    #[cfg(feature = "cache_asset")]
+    fn get_cache_path(&self, path: &Path) -> Option<PathBuf> {
+        use slug::slugify;
+
+        if self.cache_resource {
+            return directories::ProjectDirs::from("", "", "bevy_web_asset").map(|user_dirs| {
+                // extract the directory part of the path, and if it doesn't exist, use the path itself
+                let url_dir = path.parent().unwrap_or(path).to_string_lossy();
+
+                // Extract the last component of the path, to use as the filename
+                let url_filename = path
+                    .file_name()
+                    .map(|filename| filename.to_string_lossy())
+                    .unwrap_or(std::borrow::Cow::Borrowed("filename"))
+                    .to_string();
+
+                // Build the final path by combining cache directory, slug, and filename
+                user_dirs
+                    .cache_dir()
+                    .join(slugify(url_dir))
+                    .join(url_filename)
+            });
+        }
+        None
+    }
+
+    #[cfg(not(feature = "cache_asset"))]
+    fn get_cache_path(&self, _: &Path) -> Option<PathBuf> {
+        None
+    }
+}
+
+/// Treats paths as urls to load assets from.
+pub enum WebAssetReaderConnection {
     /// Unencrypted connections.
     Http,
     /// Use TLS for setting up connections.
     Https,
 }
 
-impl WebAssetReader {
+impl WebAssetReaderConnection {
     fn make_uri(&self, path: &Path) -> PathBuf {
         PathBuf::from(match self {
-            Self::Http => "http://",
-            Self::Https => "https://",
+            WebAssetReaderConnection::Http => "http://",
+            WebAssetReaderConnection::Https => "https://",
         })
         .join(path)
     }
@@ -31,7 +85,7 @@ impl WebAssetReader {
 }
 
 #[cfg(target_arch = "wasm32")]
-async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
+async fn get<'a>(path: PathBuf, _: Option<PathBuf>) -> Result<Box<Reader<'a>>, AssetReaderError> {
     use bevy::asset::io::VecReader;
     use js_sys::Uint8Array;
     use wasm_bindgen::JsCast;
@@ -81,11 +135,23 @@ async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
+async fn get<'a>(
+    path: PathBuf,
+    cache_path: Option<PathBuf>,
+) -> Result<Box<dyn Reader>, AssetReaderError> {
+    use std::fs;
     use std::future::Future;
     use std::io;
     use std::pin::Pin;
     use std::task::{Context, Poll};
+
+    if let Some(cache_path) = cache_path.as_ref() {
+        if cache_path.exists() {
+            // TODO: fallback to deleting cache if it fails to read, and re-download the file?
+            // Currently user can delete the cache manually to trigger a re-download.
+            return Ok(Box::new(VecReader::new(fs::read(cache_path)?)));
+        }
+    }
 
     use bevy::asset::io::VecReader;
     use surf::StatusCode;
@@ -136,11 +202,29 @@ async fn get(path: PathBuf) -> Result<Box<dyn Reader>, AssetReaderError> {
     })?;
 
     match response.status() {
-        StatusCode::Ok => Ok(Box::new(VecReader::new(
-            ContinuousPoll(response.body_bytes())
+        StatusCode::Ok => {
+            let buf = ContinuousPoll(response.body_bytes())
                 .await
-                .map_err(|_| AssetReaderError::NotFound(path.to_path_buf()))?,
-        )) as _),
+                .map_err(|_| AssetReaderError::NotFound(path.to_path_buf()))?;
+
+            #[cfg(feature = "cache_asset")]
+            if let Some(cache_path) = cache_path {
+                use std::io::Write;
+
+                if let Some(parent_dirs) = cache_path.parent() {
+                    fs::create_dir_all(parent_dirs)?;
+                }
+                let mut file = fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(&cache_path)?;
+                // write result to disk, then return the result as a file reader
+                file.write_all(buf.as_slice())?;
+                return Ok(Box::new(VecReader::new(fs::read(&cache_path)?)));
+            }
+            Ok(Box::new(VecReader::new(buf)) as _)
+        }
         StatusCode::NotFound => Err(AssetReaderError::NotFound(path)),
         code => Err(AssetReaderError::Io(
             io::Error::new(
@@ -161,12 +245,29 @@ impl AssetReader for WebAssetReader {
         &'a self,
         path: &'a Path,
     ) -> impl ConditionalSendFuture<Output = Result<Box<dyn Reader>, AssetReaderError>> {
-        get(self.make_uri(path))
+        let uri = self.connection.make_uri(path);
+
+        let cache_path = self.get_cache_path(&uri);
+        get(uri, cache_path)
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<dyn Reader>, AssetReaderError> {
-        match self.make_meta_uri(path) {
-            Some(uri) => get(uri).await,
+        if self.reject_meta_request {
+            // see https://github.com/johanhelsing/bevy_web_asset/issues/28
+            // too many request made to .meta can cause issue
+            return Err(AssetReaderError::NotFound("meta request rejected".into()));
+        }
+
+        match self.connection.make_meta_uri(path) {
+            Some(uri) => {
+                let cache_path = self.get_cache_path(&uri);
+                match get(uri, cache_path).await {
+                    Ok(reader) => Ok(reader),
+                    Err(err) => Err(AssetReaderError::NotFound(
+                        format!("Error loading meta: {err}").into(),
+                    )),
+                }
+            }
             None => Err(AssetReaderError::NotFound(
                 "source path has no extension".into(),
             )),
@@ -181,7 +282,7 @@ impl AssetReader for WebAssetReader {
         &'a self,
         path: &'a Path,
     ) -> Result<Box<PathStream>, AssetReaderError> {
-        Err(AssetReaderError::NotFound(self.make_uri(path)))
+        Err(AssetReaderError::NotFound(self.connection.make_uri(path)))
     }
 }
 
@@ -192,7 +293,7 @@ mod tests {
     #[test]
     fn make_http_uri() {
         assert_eq!(
-            WebAssetReader::Http
+            WebAssetReaderConnection::Http
                 .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
                 .to_str()
                 .unwrap(),
@@ -203,7 +304,7 @@ mod tests {
     #[test]
     fn make_https_uri() {
         assert_eq!(
-            WebAssetReader::Https
+            WebAssetReaderConnection::Https
                 .make_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
                 .to_str()
                 .unwrap(),
@@ -214,7 +315,7 @@ mod tests {
     #[test]
     fn make_http_meta_uri() {
         assert_eq!(
-            WebAssetReader::Http
+            WebAssetReaderConnection::Http
                 .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
                 .expect("cannot create meta uri")
                 .to_str()
@@ -226,7 +327,7 @@ mod tests {
     #[test]
     fn make_https_meta_uri() {
         assert_eq!(
-            WebAssetReader::Https
+            WebAssetReaderConnection::Https
                 .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon.png"))
                 .expect("cannot create meta uri")
                 .to_str()
@@ -238,7 +339,8 @@ mod tests {
     #[test]
     fn make_https_without_extension_meta_uri() {
         assert_eq!(
-            WebAssetReader::Https.make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon")),
+            WebAssetReaderConnection::Https
+                .make_meta_uri(Path::new("s3.johanhelsing.studio/dump/favicon")),
             None
         );
     }


### PR DESCRIPTION
This draft PR introduces disk-based caching for online resources on PC (WASM support is not implemented, but browsers already handle resource caching natively). Open to feedback and discussion.

This is useful to only download the online resources on first run (if it's not already on-disk)

### Downside
Once a resource is cached on disk, it remains indefinitely and won't attempt to retrieve updated versions, as there is no reconnection to the remote host.

### Result:
```sh
$ tree ~/.cache/bevy_web_asset/

$HOME/.cache/bevy_web_asset/
├── https-cdn-jsdelivr-net-gh-files-HASH-meshes
│   ├── file1.dae
│   └── file2.stl
├── https-cdn-jsdelivr-net-gh-files-HASH-assets-meshes-collision
│   ├── finger.stl
│   ├── hand.stl
│   ├── link0.stl
│   ├── link1.stl
│   ├── link2.stl
│   ├── link3.stl
│   ├── link4.stl
│   ├── link5.stl
│   ├── link6.stl
│   └── link7.stl
├── https-cdn-jsdelivr-net-gh-files-HASH-assets-meshes-visual
│   ├── finger.dae
│   ├── hand.dae
│   ├── link0.dae
│   ├── link1.dae
│   ├── link2.dae
│   ├── link3.dae
│   ├── link4.dae
│   ├── link5.dae
│   ├── link6.dae
│   └── link7.dae
...
```